### PR TITLE
Deals with arguments in mixing sequenced and named style are available

### DIFF
--- a/lib/Data/Validator/Role/SmartSequenced.pm
+++ b/lib/Data/Validator/Role/SmartSequenced.pm
@@ -1,0 +1,34 @@
+package Data::Validator::Role::SmartSequenced;
+use Mouse::Role;
+use Mouse::Util::TypeConstraints ();
+
+around initialize => sub {
+    shift; # original method; not used
+    my $self = shift;
+
+    my %args;
+    if( @_ and Mouse::Util::TypeConstraints::HashRef($_[-1])
+        and @_ != grep { not $_->{optional} and not exists $_->{default} and not exists $_[-1]->{$_->{name}} } @{$self->rules} )
+    {
+        %args = %{ pop @_ };
+    }
+
+    my $rules = $self->rules;
+    foreach my $i( 0 .. (@_ - 1) ) {
+        my $rule = $rules->[$i] || +{ name => "[$i]" };
+        $args{ $rule->{name} } = $_[$i];
+    }
+
+    return \%args;
+};
+
+no Mouse::Role;
+1;
+__END__
+
+=head1 NAME
+
+Data::Validator::Role::SmartSequenced - Deals with sequenced and named parameters
+
+=cut
+

--- a/t/109_smart_sequenced.t
+++ b/t/109_smart_sequenced.t
@@ -1,0 +1,107 @@
+#!perl -w
+use strict;
+use Test::More;
+
+use Data::Validator;
+
+my $v = Data::Validator->new(
+    foo => 'Num',
+    bar => 'Num',
+)->with('SmartSequenced');
+
+isa_ok $v, 'Data::Validator';
+
+my $args = $v->validate(42, 1);
+is_deeply $args, { foo => 42, bar => 1 };
+
+$args = $v->validate(3.14, 2.0);
+is_deeply $args, { foo => 3.14, bar => 2.0 };
+
+
+note 'differ from StrictSequenced';
+
+eval {
+    $v->validate({});
+};
+like $@, qr/Missing parameter: 'foo'/, 'missing parameters';    # differ from StrictSequenced
+like $@, qr/Missing parameter: 'bar'/, 'missing parameters';
+
+eval {
+    $v->validate();
+};
+like $@, qr/Missing parameter: 'foo'/, 'missing parameters';
+like $@, qr/Missing parameter: 'bar'/, 'missing parameters';
+
+eval {
+    $v->validate({foo => 'bar', bar => 1});
+};
+like $@, qr/Invalid value for 'foo': Validation failed for 'Num' with value/, 'missing parameters';
+unlike $@, qr/Missing parameter: 'bar'/, 'found parameters';    # differ from StrictSequenced
+
+eval {
+    $v->validate('bar', 1);
+};
+like $@, qr/Validation failed for 'Num' with value bar/, 'validation falure';
+
+eval {
+    $v->validate(42, 'bar');
+};
+like $@, qr/Validation failed for 'Num' with value bar/, 'validation falure';
+
+$v->validate(3.14, { bar => 10 });    # differ from StrictSequenced
+
+eval {
+    $v->validate(1, 2, 3, 4);
+};
+like $@, qr/Unknown parameter:/;
+
+
+note 'differ from Sequenced';
+
+$v = Data::Validator->new(
+    foo => 'Num',
+    bar => 'HashRef',
+)->with('Sequenced');
+
+$args = $v->validate({ foo => 42, bar => { key => 'value' } });
+is_deeply $args, { foo => 42, bar => { key => 'value' } };
+
+eval {
+    $v->validate(42, { key => 'value' });
+};
+like $@, qr/Missing parameter: 'bar'/, 'missing parameters';
+like $@, qr/Unknown parameter: 'key'/, 'unexpected expansion of last hashref';
+
+$v = Data::Validator->new(
+    foo => 'Num',
+    bar => 'HashRef',
+)->with('SmartSequenced');
+
+$args = $v->validate({ foo => 42, bar => { key => 'value' } });
+is_deeply $args, { foo => 42, bar => { key => 'value' } }, 'same as Sequenced';
+
+$args = $v->validate(42, { key => 'value' });    # differ from Sequenced
+is_deeply $args, { foo => 42, bar => { key => 'value' } }, 'deals with last hashref';
+
+
+note 'SmartSequenced';
+
+$v = Data::Validator->new(
+    foo => 'Num',
+    bar => { isa => 'Num', optional => 1 },
+    baz => { isa => 'Num', default => 2.72 },
+)->with('SmartSequenced');
+
+$args = $v->validate(42, { bar => 1, baz => 2.718 });
+is_deeply $args, { foo => 42, bar => 1, baz => 2.718 }, 'required as sequenced, the others as hashref';
+
+$args = $v->validate(42);
+is_deeply $args, { foo => 42, baz => 2.72 }, 'required as sequenced';
+
+$args = $v->validate({ foo => 42 });
+is_deeply $args, { foo => 42, baz => 2.72 }, 'required as hashref';
+
+$args = $v->validate({ foo => 3.14, bar => 2.0, baz => 2.718 });
+is_deeply $args, { foo => 3.14, bar => 2.0, baz => 2.718 }, 'all as hashref';
+
+done_testing;


### PR DESCRIPTION
`SmartSequenced` can deals with arguments in mixing sequenced and named style.
It solves the #3 unexpected expansion of last hashref.

Usage is as follows. 
- all parameters as sequenced
- all parameters as hashref
- required parameters as sequenced, and optional parameters as hashref
